### PR TITLE
2.3.0: Correct name of `keyPeople` field.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ __Maven__
   <dependency>
     <groupId>com.fullcontact</groupId>
     <artifactId>fullcontact4j</artifactId>
-    <version>2.2.1</version>
+    <version>(version here)</version>
   </dependency>
 </dependencies>
 ```
@@ -37,7 +37,7 @@ repositories {
 }
 
 dependencies {
-    compile group: "com.fullcontact", name: "fullcontact4j", version: "2.2.1"
+    compile group: "com.fullcontact", name: "fullcontact4j", version: "(version here)"
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.fullcontact</groupId>
     <artifactId>fullcontact4j</artifactId>
     <name>FullContact Java Bindings</name>
-    <version>2.2.1</version>
+    <version>2.3.0</version>
     <dependencies>
 
         <dependency>

--- a/src/main/java/com/fullcontact/api/libs/fullcontact4j/http/company/model/CompanyOrganization.java
+++ b/src/main/java/com/fullcontact/api/libs/fullcontact4j/http/company/model/CompanyOrganization.java
@@ -181,14 +181,6 @@ public class CompanyOrganization {
         return contactInfo;
     }
 
-    /**
-     * @deprecated Use getKeyPeople().
-     */
-    @Deprecated
-    public List<? extends KeyEmployee> getKeyEmployees() {
-        return keyPeople;
-    }
-
     public List<KeyPerson> getKeyPeople() {
         return keyPeople;
     }

--- a/src/main/java/com/fullcontact/api/libs/fullcontact4j/http/company/model/CompanyOrganization.java
+++ b/src/main/java/com/fullcontact/api/libs/fullcontact4j/http/company/model/CompanyOrganization.java
@@ -15,13 +15,7 @@ public class CompanyOrganization {
     private List<CompanyUrl> images = Collections.emptyList();
     private List<String> keywords = Collections.emptyList();
 
-
-    /**
-     * @deprecated This class only exists for backwards-compatibility; use
-     * KeyPerson instead.
-     */
-    @Deprecated
-    public static class KeyEmployee {
+    public static class KeyPerson {
         private String name;
         private String title;
         private String link;
@@ -38,8 +32,6 @@ public class CompanyOrganization {
             return link;
         }
     }
-
-    public static class KeyPerson extends KeyEmployee { }
 
     public static class CompanyUrl {
         private String url;

--- a/src/main/java/com/fullcontact/api/libs/fullcontact4j/http/company/model/CompanyOrganization.java
+++ b/src/main/java/com/fullcontact/api/libs/fullcontact4j/http/company/model/CompanyOrganization.java
@@ -10,12 +10,17 @@ public class CompanyOrganization {
     private String founded;
     private String overview;
     private CompanyContactInfo contactInfo;
-    private List<KeyEmployee> keyEmployees = Collections.emptyList();
+    private List<KeyPerson> keyPeople = Collections.emptyList();
     private List<CompanyUrl> links = Collections.emptyList();
     private List<CompanyUrl> images = Collections.emptyList();
     private List<String> keywords = Collections.emptyList();
 
 
+    /**
+     * @deprecated This class only exists for backwards-compatibility; use
+     * KeyPerson instead.
+     */
+    @Deprecated
     public static class KeyEmployee {
         private String name;
         private String title;
@@ -34,6 +39,8 @@ public class CompanyOrganization {
         }
     }
 
+    public static class KeyPerson extends KeyEmployee { }
+
     public static class CompanyUrl {
         private String url;
         private String label;
@@ -46,7 +53,7 @@ public class CompanyOrganization {
             return label;
         }
     }
-    
+
     public static class CompanyContactInfo {
         private List<CompanyEmailAddress> emailAddresses;
         private List<CompanyPhoneNumber> phoneNumbers;
@@ -64,7 +71,7 @@ public class CompanyOrganization {
             return addresses;
         }
     }
-    
+
     public static class CompanyPhoneNumber {
         private String number;
         private String label;
@@ -90,7 +97,7 @@ public class CompanyOrganization {
             return label;
         }
     }
-    
+
     public static class CompanyAddress {
         private String addressLine1;
         private String addressLine2;
@@ -182,8 +189,16 @@ public class CompanyOrganization {
         return contactInfo;
     }
 
-    public List<KeyEmployee> getKeyEmployees() {
-        return keyEmployees;
+    /**
+     * @deprecated Use getKeyPeople().
+     */
+    @Deprecated
+    public List<? extends KeyEmployee> getKeyEmployees() {
+        return keyPeople;
+    }
+
+    public List<KeyPerson> getKeyPeople() {
+        return keyPeople;
     }
 
     public List<CompanyUrl> getLinks() {


### PR DESCRIPTION
I wasn't too sure how much we care about backwards compatibility in this
part of the API, given that it never actually worked. For now, I went
with what I'm pretty sure is fully backwards binary-compatible largely
source-compatible.

Then again, since it didn't actually work before, it seems unlikely
anyone is actually using the `keyEmployee` stuff, so maybe it can just
be removed outright.

@McManCSU @ParisMi 