### PR TITLE
Set access token for view requests in CR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.fullcontact</groupId>
     <artifactId>fullcontact4j</artifactId>
     <name>FullContact Java Bindings</name>
-    <version>2.5.0</version>
+    <version>2.5.1</version>
     <dependencies>
 
         <dependency>

--- a/src/main/java/com/fullcontact/api/libs/fullcontact4j/http/cardreader/CardReaderViewRequest.java
+++ b/src/main/java/com/fullcontact/api/libs/fullcontact4j/http/cardreader/CardReaderViewRequest.java
@@ -14,7 +14,17 @@ public class CardReaderViewRequest extends FCRequest<CardReaderFullResponse> {
     public CardReaderViewRequest(String accessToken, String id, Map<String, String> params) {
         super(params);
         this.id = id;
+        this.accessToken = accessToken;
     }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
     @Override
     protected void makeRequest(FullContactApi api, Callback<CardReaderFullResponse> callback) {
         api.viewCard(accessToken, params, id, callback);
@@ -44,7 +54,7 @@ public class CardReaderViewRequest extends FCRequest<CardReaderFullResponse> {
         }
 
         public Builder accessToken(String token) {
-            accessToken = token;
+            this.accessToken = token;
             return this;
         }
 

--- a/src/test/java/com/fullcontact/api/libs/fullcontact4j/http/cardreader/CardReaderViewRequestTest.java
+++ b/src/test/java/com/fullcontact/api/libs/fullcontact4j/http/cardreader/CardReaderViewRequestTest.java
@@ -1,0 +1,22 @@
+package com.fullcontact.api.libs.fullcontact4j.http.cardreader;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Skiggz
+ * @since 12/30/15.
+ */
+public class CardReaderViewRequestTest {
+
+    @Test
+    public void testNotStrippingToken() {
+        CardReaderViewRequest request = new CardReaderViewRequest("foobar", "id", new HashMap<String, String>());
+        assertEquals("foobar", request.getAccessToken());
+        assertEquals("id", request.getId());
+    }
+
+}


### PR DESCRIPTION
* View requests were stripping access token, not sure if intentional

@ParisMi @Xorlev 

Janis was trying to update card reader android and this was stripping out access token on every request. Not sure if it was intentional, but I fixed it. This allows the upload request to set access token which is passed onto the view request.