### PR TITLE
PersonRequest: remove facebook lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Java client for the [FullContact API](http://www.fullcontact.com/docs).
 
-For FullContact4j 2.0, we've designed the client from the bottom up with tons of cool new stuff.
+For FullContact4j 2.0 and later, we've designed the client from the bottom up with tons of cool new stuff.
 
 See the changelog [here.](https://github.com/fullcontact/fullcontact4j/wiki/changelog)
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.fullcontact</groupId>
     <artifactId>fullcontact4j</artifactId>
     <name>FullContact Java Bindings</name>
-    <version>2.5.1</version>
+    <version>3.0.0</version>
     <dependencies>
 
         <dependency>

--- a/src/main/java/com/fullcontact/api/libs/fullcontact4j/FCConstants.java
+++ b/src/main/java/com/fullcontact/api/libs/fullcontact4j/FCConstants.java
@@ -31,8 +31,6 @@ public class FCConstants {
     public static final String PARAM_PERSON_EMAIL_MD5 = "emailMD5";
     public static final String PARAM_PERSON_QUEUE = "queue";
     public static final String PARAM_PERSON_TWITTER = "twitter";
-    public static final String PARAM_PERSON_FACEBOOK = "facebookUsername";
-    public static final String PARAM_PERSON_FACEBOOK_ID = "facebookId";
     public static final String PARAM_PERSON_LOOKUP = "lookup";
     public static final String PARAM_PERSON_PHONE = "phone";
     public static final String PARAM_PERSON_PHONE_COUNTRY_CODE = "countryCode";

--- a/src/main/java/com/fullcontact/api/libs/fullcontact4j/http/person/PersonRequest.java
+++ b/src/main/java/com/fullcontact/api/libs/fullcontact4j/http/person/PersonRequest.java
@@ -51,16 +51,6 @@ public class PersonRequest extends FCRequest<PersonResponse> {
             return this;
         }
 
-        public Builder facebookName(String facebookName) {
-            params.put(FCConstants.PARAM_PERSON_FACEBOOK, facebookName);
-            return this;
-        }
-        
-        public Builder facebookId(String facebookId) {
-            params.put(FCConstants.PARAM_PERSON_FACEBOOK_ID, facebookId);
-            return this;
-        }
-
         public Builder lookup(String lookupValue) {
             params.put(FCConstants.PARAM_PERSON_LOOKUP, lookupValue);
             return this;
@@ -76,7 +66,7 @@ public class PersonRequest extends FCRequest<PersonResponse> {
                 }
                 if(foundSearchParams > 1) {
                     throw new IllegalArgumentException("A person request can only have one of the following " +
-                            "search parameters: email, emailMd5, facebook, facebookId, twitter handle, phone.");
+                            "search parameters: email, emailMd5, twitter handle, phone.");
                 }
             }
         }
@@ -92,7 +82,7 @@ public class PersonRequest extends FCRequest<PersonResponse> {
         }
 
         public static final List<String> SEARCH_PARAMS = Arrays.asList(FCConstants.PARAM_PERSON_EMAIL,
-                FCConstants.PARAM_PERSON_FACEBOOK, FCConstants.PARAM_PERSON_EMAIL_MD5, FCConstants.PARAM_PERSON_TWITTER,
-                FCConstants.PARAM_PERSON_FACEBOOK_ID, FCConstants.PARAM_PERSON_PHONE, FCConstants.PARAM_PERSON_LOOKUP);
+                FCConstants.PARAM_PERSON_EMAIL_MD5, FCConstants.PARAM_PERSON_TWITTER, FCConstants.PARAM_PERSON_PHONE,
+                FCConstants.PARAM_PERSON_LOOKUP);
     }
 }


### PR DESCRIPTION
Removes Facebook lookups (username and ID) from FullContact4j, as they now are not available in Person API.

Please contact `support@fullcontact.com` if this is a problem for you.