### PR TITLE
Access rate limit info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.fullcontact</groupId>
     <artifactId>fullcontact4j</artifactId>
     <name>FullContact Java Bindings</name>
-    <version>3.1.0</version>
+    <version>3.2.0</version>
     <dependencies>
 
         <dependency>

--- a/src/main/java/com/fullcontact/api/libs/fullcontact4j/FullContact.java
+++ b/src/main/java/com/fullcontact/api/libs/fullcontact4j/FullContact.java
@@ -165,7 +165,7 @@ public class FullContact {
 
     public void shutdown() {
         isShutdown = true;
-        httpInterface.getRequestExecutorHandler().shutdown();
+        httpInterface.getRequestHandler().shutdown();
     }
 
 

--- a/src/main/java/com/fullcontact/api/libs/fullcontact4j/FullContactException.java
+++ b/src/main/java/com/fullcontact/api/libs/fullcontact4j/FullContactException.java
@@ -1,5 +1,7 @@
 package com.fullcontact.api.libs.fullcontact4j;
 
+import com.fullcontact.api.libs.fullcontact4j.http.FCRateLimits;
+
 @SuppressWarnings("serial")
 
 /**
@@ -12,9 +14,10 @@ public class FullContactException extends Exception {
         super(message);
     }
 
-    public FullContactException(String message, Integer error, Throwable cause) {
+    public FullContactException(String message, Integer error, Throwable cause, FCRateLimits rateLimits) {
         super(message, cause);
         errorCode = error;
+        this.rateLimits = rateLimits;
     }
 
     public FullContactException(String message, Throwable cause) {
@@ -22,6 +25,7 @@ public class FullContactException extends Exception {
     }
 
     private Integer errorCode;
+    private FCRateLimits rateLimits;
 
     /**
      * Returns the HTTP error code that caused the exception,
@@ -32,4 +36,16 @@ public class FullContactException extends Exception {
         return errorCode;
     }
 
+    /**
+     * Returns the rate limit information returned by FullContact for this request.
+     *
+     * If this error is not an HTTP-based exception (i.e. FullContact API returning error 500), this will be null.
+     */
+    public FCRateLimits getRateLimitsOrNull() {
+        return rateLimits;
+    }
+
+    public void setRateLimits(FCRateLimits rateLimits) {
+        this.rateLimits = rateLimits;
+    }
 }

--- a/src/main/java/com/fullcontact/api/libs/fullcontact4j/enums/RateLimiterConfig.java
+++ b/src/main/java/com/fullcontact/api/libs/fullcontact4j/enums/RateLimiterConfig.java
@@ -34,4 +34,8 @@ public class RateLimiterConfig {
      */
     public static final RateLimiterConfig BURST = new RateLimiterConfig(DEFAULT_REQUESTS_PER_SECOND, 8.0);
 
+    /**
+     * Requests will not be controlled. You must manage rate limits by yourself.
+     */
+    public static final RateLimiterConfig DISABLED = new RateLimiterConfig(-1, -1);
 }

--- a/src/main/java/com/fullcontact/api/libs/fullcontact4j/http/FCRateLimits.java
+++ b/src/main/java/com/fullcontact/api/libs/fullcontact4j/http/FCRateLimits.java
@@ -1,0 +1,62 @@
+package com.fullcontact.api.libs.fullcontact4j.http;
+
+import com.fullcontact.api.libs.fullcontact4j.FCConstants;
+import com.fullcontact.api.libs.fullcontact4j.Utils;
+import retrofit.client.Header;
+import retrofit.client.Response;
+
+public class FCRateLimits {
+
+    private int requestsRemaining;
+    private int maxRequestsPerSecond;
+    private int secondsToReset;
+
+    public FCRateLimits(int requestsRemaining, int maxRequestsPerSecond, int secondsToReset) {
+        this.requestsRemaining = requestsRemaining;
+        this.maxRequestsPerSecond = maxRequestsPerSecond;
+        this.secondsToReset = secondsToReset;
+    }
+
+    public int getMaxRequestsPerSecond() {
+        return maxRequestsPerSecond;
+    }
+
+    public int getSecondsToReset() {
+        return secondsToReset;
+    }
+
+    public int getRequestsRemaining() {
+        return requestsRemaining;
+    }
+
+    public static FCRateLimits fromResponseNullable(Response response) {
+        Integer maxRequestsPerSecond = null;
+        Integer requestsRemaining = null;
+        Integer secondsUntilNextSession = null;
+
+        try {
+            for (Header h : response.getHeaders()) {
+                if (FCConstants.HEADER_RATE_LIMIT_PER_MINUTE.equals(h.getName())) {
+                    maxRequestsPerSecond = Integer.parseInt(h.getValue()) / 60;
+                }
+                if (FCConstants.HEADER_RATE_LIMIT_REMAINING.equals(h.getName())) {
+                    requestsRemaining = Integer.parseInt(h.getValue());
+                }
+                if (FCConstants.HEADER_RATE_LIMIT_RESET_TIME.equals(h.getName())) {
+                    secondsUntilNextSession = Integer.parseInt(h.getValue());
+                }
+            }
+
+        } catch(Exception e) {
+            Utils.info("Error extracting rate limit headers: " + response.getHeaders());
+            return null;
+        }
+
+        if(maxRequestsPerSecond == null || requestsRemaining == null || secondsUntilNextSession == null) {
+            Utils.info("Missing rate limit headers info, not including in response. Raw Headers: " + response.getHeaders());
+            return null;
+        }
+
+        return new FCRateLimits(requestsRemaining, maxRequestsPerSecond, secondsUntilNextSession);
+    }
+}

--- a/src/main/java/com/fullcontact/api/libs/fullcontact4j/http/FCRequestHandler.java
+++ b/src/main/java/com/fullcontact/api/libs/fullcontact4j/http/FCRequestHandler.java
@@ -1,0 +1,25 @@
+package com.fullcontact.api.libs.fullcontact4j.http;
+
+import com.fullcontact.api.libs.fullcontact4j.FullContactApi;
+
+public interface FCRequestHandler {
+
+    public void notifyRateLimits(FCRateLimits rateLimits);
+
+    public void shutdown();
+
+    public <T extends FCResponse> void sendRequestAsync(final FullContactApi api, final FCRequest<T> req,
+                                                        final FCRetrofitCallback<T> callback);
+
+    class NoRateLimitRequestHandler implements FCRequestHandler {
+
+        public void notifyRateLimits(FCRateLimits rateLimits) {}
+
+        public void shutdown() {}
+
+        public <T extends FCResponse> void sendRequestAsync(FullContactApi api, FCRequest<T> req, FCRetrofitCallback
+                    <T> callback) {
+            req.makeRequest(api, callback);
+        }
+    }
+}

--- a/src/main/java/com/fullcontact/api/libs/fullcontact4j/http/FCResponse.java
+++ b/src/main/java/com/fullcontact/api/libs/fullcontact4j/http/FCResponse.java
@@ -1,5 +1,7 @@
 package com.fullcontact.api.libs.fullcontact4j.http;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 /**
  * A very simple class to represent responses back from FullContact APIs.
  * The designation is more important than the functionality.
@@ -8,6 +10,7 @@ package com.fullcontact.api.libs.fullcontact4j.http;
 public abstract class FCResponse {
 
     public int status;
+    @JsonIgnore private FCRateLimits rateLimits;
 
     public int getStatus() {
         return status;
@@ -15,5 +18,19 @@ public abstract class FCResponse {
 
     public String toString() {
         return this.getClass().getSimpleName() + ":" + status;
+    }
+
+    /**
+     * Get the rate limit information returned by FullContact for this request.
+     *
+     * Returns null if there is no rate limit information in the response headers or there was an error fetching it.
+     */
+    @JsonIgnore
+    public FCRateLimits getRateLimitsOrNull() {
+        return rateLimits;
+    }
+
+    void setRateLimits(FCRateLimits rateLimits) {
+        this.rateLimits = rateLimits;
     }
 }

--- a/src/main/java/com/fullcontact/api/libs/fullcontact4j/http/FCRetrofitCallback.java
+++ b/src/main/java/com/fullcontact/api/libs/fullcontact4j/http/FCRetrofitCallback.java
@@ -7,8 +7,6 @@ import retrofit.RetrofitError;
 import retrofit.client.Response;
 import retrofit.converter.ConversionException;
 
-import static retrofit.RetrofitError.Kind.CONVERSION;
-
 /**
  * The core retrofit callback that all FCCallbacks use.
  * Before FCCallback receives the success() or failure() call,
@@ -28,11 +26,11 @@ public class FCRetrofitCallback<T extends FCResponse> implements Callback<T> {
     }
 
     public void success(T t, Response response) {
-        RequestExecutorHandler requestHandler = httpInterface.getRequestExecutorHandler();
+        FCRequestHandler requestHandler = httpInterface.getRequestHandler();
         FCRateLimits rateLimits = FCRateLimits.fromResponseNullable(response);
 
         if(rateLimits != null) {
-            requestHandler.notifyHeaders(rateLimits);
+            requestHandler.notifyRateLimits(rateLimits);
             t.setRateLimits(rateLimits);
         }
 

--- a/src/test/java/com/fullcontact/api/libs/fullcontact4j/FullContactClientTests.java
+++ b/src/test/java/com/fullcontact/api/libs/fullcontact4j/FullContactClientTests.java
@@ -48,7 +48,7 @@ public class FullContactClientTests {
     //counterparts
     public void asyncTest() throws Exception {
         FullContact client = FullContact.withApiKey("bad-api-key").build();
-        client.httpInterface.setRequestExecutorHandler(new MockRequestHandler(RateLimiterConfig.SMOOTH, 1));
+        client.httpInterface.setRequestHandler(new MockRequestHandler(RateLimiterConfig.SMOOTH, 1));
         final CountDownLatch latch = new CountDownLatch(REQUEST_AMOUNT);
         //async
         for (int i = 0; i != REQUEST_AMOUNT; i++) {
@@ -78,7 +78,7 @@ public class FullContactClientTests {
     @Test(timeout = 8000)
     public void syncTest() throws Exception {
         FullContact client = FullContact.withApiKey("bad-api-key").build();
-        client.httpInterface.setRequestExecutorHandler(new MockRequestHandler(RateLimiterConfig.SMOOTH, 1));
+        client.httpInterface.setRequestHandler(new MockRequestHandler(RateLimiterConfig.SMOOTH, 1));
         //sync
         for (int i = 0; i != REQUEST_AMOUNT; i++) {
             final PersonRequest req = client.buildPersonRequest().email(UUID.randomUUID().toString()).build();


### PR DESCRIPTION
- adds the ability to inspect rate limit headers from an error response or FCResponse
- adds RateLimiterConfig.DISABLED

alternative implementation of https://github.com/fullcontact/fullcontact4j/pull/29 -- the API is almost identical.

Example Usage:
```
        PersonResponse response = fc.sendRequest(fc.buildPersonRequest().email("paris@fullcontact.com").build());
        response.getRateLimitsOrNull().getSecondsToReset(); //or other info
```

FullContactException has a similar field.