### PR TITLE
Remove all references to Java 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.fullcontact</groupId>
     <artifactId>fullcontact4j</artifactId>
     <name>FullContact Java Bindings</name>
-    <version>3.3.2</version>
+    <version>3.3.3</version>
     <dependencies>
 
         <dependency>

--- a/src/main/java/com/fullcontact/api/libs/fullcontact4j/Utils.java
+++ b/src/main/java/com/fullcontact/api/libs/fullcontact4j/Utils.java
@@ -2,13 +2,9 @@ package com.fullcontact.api.libs.fullcontact4j;
 
 import org.apache.commons.codec.binary.Base64;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.logging.Level;
 
 public class Utils {
@@ -49,7 +45,8 @@ public class Utils {
     }
 
     public static String loadFileAsString(String fileName) throws IOException {
-        return new String(Files.readAllBytes(Paths.get("src/test/resources/" + fileName)));
+        InputStream is = Utils.class.getClassLoader().getResourceAsStream(fileName);
+        return new String(read(is, 1));
     }
 
     public static void log(Level l, String log) {
@@ -83,4 +80,37 @@ public class Utils {
         log(Level.FINE, log);
     }
 
+    private static final int MAX_BUFFER_SIZE = Integer.MAX_VALUE - 8;
+    private static final int BUFFER_SIZE = 8192;
+
+    // Stolen from java 7 Files.read
+    private static byte[] read(InputStream source, int initialSize) throws IOException {
+        int capacity = initialSize;
+        byte[] buf = new byte[capacity];
+        int nread = 0;
+        int n;
+        for (;;) {
+            // read to EOF which may read more or less than initialSize (eg: file
+            // is truncated while we are reading)
+            while ((n = source.read(buf, nread, capacity - nread)) > 0)
+                nread += n;
+
+            // if last call to source.read() returned -1, we are done
+            // otherwise, try to read one more byte; if that failed we're done too
+            if (n < 0 || (n = source.read()) < 0)
+                break;
+
+            // one more byte was read; need to allocate a larger buffer
+            if (capacity <= MAX_BUFFER_SIZE - capacity) {
+                capacity = Math.max(capacity << 1, BUFFER_SIZE);
+            } else {
+                if (capacity == MAX_BUFFER_SIZE)
+                    throw new OutOfMemoryError("Required array size too large");
+                capacity = MAX_BUFFER_SIZE;
+            }
+            buf = Arrays.copyOf(buf, capacity);
+            buf[nread++] = (byte)n;
+        }
+        return (capacity == nread) ? buf : Arrays.copyOf(buf, nread);
+    }
 }


### PR DESCRIPTION
Some code used in unit tests snuck into the main build. It used `Files`, which is a java 7 class. I have removed all references to it.

Also I changed our compile jobs to  use the correct version of java during compilation. :)