### PR TITLE
use java 7, okhttp 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,3 @@ The user agent and request executor thread count are also configurable. For pers
 
 ### I'm on Java 6! ###
 The last Java 6-compatible FullContact4j release was version 3.3.3.
-If you use Java 6 because you're using Android, it is highly recommended that you do not use FullContact4j.
-FC4j requires your api key to be available directly at runtime. This makes your (secret!) api key accessible to
-all users of your app. This is not a good idea. Instead, proxy all FullContact api requests through
-web servers that you control.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #FullContact4j
 
-A Java client for the [FullContact API](http://www.fullcontact.com/docs).
+A Java client for the [FullContact API](http://www.fullcontact.com/docs). Supports Java 7+.
 
 For FullContact4j 2.0 and later, we've designed the client from the bottom up with tons of cool new stuff.
 
@@ -173,3 +173,10 @@ client.setReadTimeout(3000, TimeUnit.MILLISECONDS);
 FullContact fcClient = FullContact.withApiKey("your-api-key").httpClient(client).build();
 ```
 The user agent and request executor thread count are also configurable. For person API requests, the client will rate limit the amount of requests sent based on the rate limit for your plan. It will hold a request queue and execute at the maximum every `1/ratelimit` seconds with some leeway if you haven’t sent requests in a certain period of time. __FullContact4j guarantees no Person API rate limiting exceptions only as long a single client instance is the only user of an API key__. However, if multiple instances of the client are being used simultaneously, FullContact4J cannot track your usage with high enough accuracy to guarantee that you will never get a rate limit exception (403). These may still occaisionally occur, and should be accounted for in your code. This rate limiter does NOT account for overages or quota limits. Make sure to check your [account stats](https://www.fullcontact.com/developer/docs/account-stats) periodically to avoid overages.
+
+### I'm on Java 6! ###
+The last Java 6-compatible FullContact4j release was version 3.3.3.
+If you use Java 6 because you're using Android, it is highly recommended that you do not use FullContact4j.
+FC4j requires your api key to be available directly at runtime. This makes your (secret!) api key accessible to
+all users of your app. This is not a good idea. Instead, proxy all FullContact api requests through
+web servers that you control.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.fullcontact</groupId>
     <artifactId>fullcontact4j</artifactId>
     <name>FullContact Java Bindings</name>
-    <version>3.3.3</version>
+    <version>4.0.0</version>
     <dependencies>
 
         <dependency>
@@ -34,12 +34,12 @@
         <dependency>
             <groupId>com.squareup.okhttp</groupId>
             <artifactId>okhttp</artifactId>
-            <version>1.6.0</version>
+            <version>2.3.0</version>
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp</groupId>
             <artifactId>okhttp-urlconnection</artifactId>
-            <version>1.6.0</version>
+            <version>2.3.0</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>


### PR DESCRIPTION
addresses https://github.com/fullcontact/fullcontact4j/issues/38.

from here on out, FC4J is java 7+. OkHttp 2 requires it. 3.3.3 will still work for users on java 6 but it's been 10+ years since java 6 and it's reasonable to ask users to upgrade, I think.

The only place java 6 is still in major use in 2017 is Android, which as I mention in the PR is insecure and shouldn't be done anyway.