### PR TITLE
EmailVerificationBatchRequest: allow user-specified batch ID

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.fullcontact</groupId>
     <artifactId>fullcontact4j</artifactId>
     <name>FullContact Java Bindings</name>
-    <version>5.0.0</version>
+    <version>5.1.0</version>
     <dependencies>
 
         <dependency>

--- a/src/main/java/com/fullcontact/api/libs/fullcontact4j/http/email/EmailVerificationBatchRequest.java
+++ b/src/main/java/com/fullcontact/api/libs/fullcontact4j/http/email/EmailVerificationBatchRequest.java
@@ -22,6 +22,7 @@ public class EmailVerificationBatchRequest extends FCRequest<EmailVerificationAs
     public static class Body {
         private List<String> emails;
         private String webhookUrl;
+        private String batchId;
 
         public Body(List<String> emails, String webhookUrl) {
             this.emails = emails;
@@ -40,6 +41,7 @@ public class EmailVerificationBatchRequest extends FCRequest<EmailVerificationAs
     public static class Builder extends FCRequest.BaseBuilder<Builder, EmailVerificationBatchRequest> {
         private List<String> emails;
         private String webhookUrl;
+        private String batchId;
 
         protected EmailVerificationBatchRequest createInstance() {
             return new EmailVerificationBatchRequest(new Body(emails, webhookUrl));
@@ -52,6 +54,11 @@ public class EmailVerificationBatchRequest extends FCRequest<EmailVerificationAs
 
         public Builder webhookUrl(String webhookUrl) {
             this.webhookUrl = webhookUrl;
+            return this;
+        }
+
+        public Builder batchId(String batchId) {
+            this.batchId = batchId;
             return this;
         }
 


### PR DESCRIPTION
Allows the user to specify their own batch ID for a batch request to Email Verification API. 

A custom ID must be unique among the batch IDs used with the given API key. If a request is sent to the API that reuses a batch ID, it will be rejected, causing a FullContactException when FC4j gets a non-200 response.

@ParisMi 