### PR TITLE
client: support specifying httpExecutor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.fullcontact</groupId>
     <artifactId>fullcontact4j</artifactId>
     <name>FullContact Java Bindings</name>
-    <version>5.2.0</version>
+    <version>5.3.0</version>
     <dependencies>
 
         <dependency>

--- a/src/main/java/com/fullcontact/api/libs/fullcontact4j/FullContactHttpInterface.java
+++ b/src/main/java/com/fullcontact/api/libs/fullcontact4j/FullContactHttpInterface.java
@@ -10,6 +10,7 @@ import retrofit.client.Client;
 import retrofit.converter.Converter;
 import retrofit.converter.JacksonConverter;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 
 /**
@@ -33,7 +34,7 @@ public class FullContactHttpInterface {
     private FullContactApi fullContactApi;
 
     public FullContactHttpInterface(Client httpClient, RateLimiterConfig rateLimiterConfig, String baseUrl,
-                                    ExecutorService executorService) {
+                                    ExecutorService rateLimitExecutor, Executor httpExecutor) {
         ObjectMapper mapper = new ObjectMapper();
         //Properties not present in the POJO are ignored instead of throwing exceptions
         mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
@@ -43,11 +44,11 @@ public class FullContactHttpInterface {
         if(rateLimiterConfig == RateLimiterConfig.DISABLED) {
             requestHandler = new FCRequestHandler.NoRateLimitRequestHandler();
         } else {
-            requestHandler = new RequestExecutorHandler(rateLimiterConfig, executorService);
+            requestHandler = new RequestExecutorHandler(rateLimiterConfig, rateLimitExecutor);
         }
 
         jsonConverter = new JacksonConverter(mapper);
-        RestAdapter adapter = new RestAdapter.Builder().setEndpoint(baseUrl)
+        RestAdapter adapter = new RestAdapter.Builder().setEndpoint(baseUrl).setExecutors(httpExecutor, null)
                 .setClient(httpClient).setConverter(jsonConverter).build();
         fullContactApi = adapter.create(FullContactApi.class);
         this.baseUrl = baseUrl;

--- a/src/test/java/com/fullcontact/api/libs/fullcontact4j/FullContactClientTests.java
+++ b/src/test/java/com/fullcontact/api/libs/fullcontact4j/FullContactClientTests.java
@@ -28,9 +28,9 @@ public class FullContactClientTests {
         String baseUrl = "not.fullcontact.com";
         RateLimiterConfig rateLimiterConfig = new RateLimiterConfig(10, 1);
 
-        FullContact client1 = new FullContact(new FCUrlClient(baseUrl, apiKey), rateLimiterConfig, baseUrl, Executors.newSingleThreadExecutor());
+        FullContact client1 = new FullContact(new FCUrlClient(baseUrl, apiKey), rateLimiterConfig, baseUrl, Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor());
         FullContact client2 = FullContact.withApiKey(apiKey)
-                .baseUrl(baseUrl).rateLimitExecutorService(Executors.newSingleThreadExecutor()).build();
+                .baseUrl(baseUrl).httpExecutor(Executors.newSingleThreadExecutor()).rateLimitExecutorService(Executors.newSingleThreadExecutor()).build();
         assertEquals(client1.httpInterface.getBaseUrl(), client2.httpInterface.getBaseUrl());
     }
 
@@ -112,7 +112,7 @@ public class FullContactClientTests {
         mockClient = new MockRetrofitClient("test", mockHeaders, new OkHttpClient(), BAD_API_KEY);
         //create a new FullContact client that uses an http client that never makes requests and points towards nothing
         mockFc = new FullContact(mockClient,
-                RateLimiterConfig.SMOOTH, "http://badbadbad.not.exist", Executors.newSingleThreadExecutor());
+                RateLimiterConfig.SMOOTH, "http://badbadbad.not.exist", Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor());
     }
 
     @AfterClass


### PR DESCRIPTION
Allows Retrofit's HTTP executor to be specified (in this case, to allow a GCE user to specify their own ThreadFactory).

Retrofit also supports a callback executor, but by default, this is a synchronous executor that does not use threads. So I think we're ok there.