### PR TITLE
RequestExecutorHandler: actually update rate limits based on headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.fullcontact</groupId>
     <artifactId>fullcontact4j</artifactId>
     <name>FullContact Java Bindings</name>
-    <version>5.3.0</version>
+    <version>5.3.1</version>
     <dependencies>
 
         <dependency>

--- a/src/main/java/com/fullcontact/api/libs/fullcontact4j/http/RequestExecutorHandler.java
+++ b/src/main/java/com/fullcontact/api/libs/fullcontact4j/http/RequestExecutorHandler.java
@@ -55,7 +55,7 @@ public class RequestExecutorHandler implements FCRequestHandler {
 
         int requestsRemaining = rateLimits.getRequestsRemaining();
         int secondsToReset = rateLimits.getSecondsToReset();
-
+        apiKeyRequestsPerSecond = rateLimits.getMaxRequestsPerSecond();
         lastKnownRateLimits = rateLimits;
 
         if (shouldUpdateRateLimit()) {


### PR DESCRIPTION
Fixed a bug where FC4J failed to auto-discover higher limits for the specified keys based on rate limit headers.