### PR TITLE
Bump spark core for security.

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -12,7 +12,7 @@
         <dependency>
             <groupId>com.sparkjava</groupId>
             <artifactId>spark-core</artifactId>
-            <version>2.1</version>
+            <version>2.7.2</version>
         </dependency>
         <dependency>
             <groupId>com.fullcontact</groupId>


### PR DESCRIPTION
Github's security review recommended updating the version of `spark-core`.  This is a dependency not of the actual `fullcontact4j` jar, but just of the example code provided in the GH project.  As such merely incrementing the version should be all we need to do.

I tested locally and everything looked fine on the new version, but please check my math :).